### PR TITLE
using tsl.lux can produce unanticipated Exception

### DIFF
--- a/examples/tsl2561_simpletest.py
+++ b/examples/tsl2561_simpletest.py
@@ -44,9 +44,9 @@ print("Integration time = {}".format(tsl.integration_time))
 print("Broadband = {}".format(broadband))
 print("Infrared = {}".format(infrared))
 if lux != None:
-  print("Lux = {}".format(lux))
+    print("Lux = {}".format(lux))
 else:
-  print("Lux = NaN")
+    print("Lux = NaN")
 
 # Disble the light sensor (to save power)
 tsl.enabled = False

--- a/examples/tsl2561_simpletest.py
+++ b/examples/tsl2561_simpletest.py
@@ -34,7 +34,7 @@ infrared = tsl.infrared
 # Get raw (luminosity) readings using tuple unpacking
 #broadband, infrared = tsl.luminosity
 
-# Get computed lux value
+# Get computed lux value (tsl.lux can return None or a float)
 lux = tsl.lux
 
 # Print results
@@ -43,7 +43,10 @@ print("Gain = {}".format(tsl.gain))
 print("Integration time = {}".format(tsl.integration_time))
 print("Broadband = {}".format(broadband))
 print("Infrared = {}".format(infrared))
-print("Lux = {}".format(lux))
+if lux != None:
+  print("Lux = {}".format(lux))
+else:
+  print("Lux = NaN")
 
 # Disble the light sensor (to save power)
 tsl.enabled = False

--- a/examples/tsl2561_simpletest.py
+++ b/examples/tsl2561_simpletest.py
@@ -43,10 +43,10 @@ print("Gain = {}".format(tsl.gain))
 print("Integration time = {}".format(tsl.integration_time))
 print("Broadband = {}".format(broadband))
 print("Infrared = {}".format(infrared))
-if lux != None:
+if lux is not None:
     print("Lux = {}".format(lux))
 else:
-    print("Lux = NaN")
+    print("Lux value is None. Possible sensor underrange or overrange.")
 
 # Disble the light sensor (to save power)
 tsl.enabled = False


### PR DESCRIPTION
using tsl.lux without consideration of all possible values will eventually produce an unanticipated Exception. 
return values can be a float, 0, or None. 
implicit datatype handling provides float(0) == 0.0 but float(None) will produce an Exception. 
alternatively, one should check isinstance( tsl.lux, Float ) but that would not explicitly show tsl.lux can be None in this example.