### PR TITLE
Ensure a float return for lux.

### DIFF
--- a/adafruit_tsl2561.py
+++ b/adafruit_tsl2561.py
@@ -107,7 +107,7 @@ class TSL2561():
 
     @property
     def lux(self):
-        """The computed lux value."""
+        """The computed lux value or None when value is not computable."""
         return self._compute_lux()
 
     @property
@@ -177,7 +177,7 @@ class TSL2561():
         elif ratio <= 1.30:
             lux = 0.00146 * ch0 - 0.00112 * ch1
         else:
-            lux = 0
+            lux = 0.
         # Pretty sure the floating point math formula on pg. 23 of datasheet
         # is based on 16x gain and 402ms integration time. Need to scale
         # result for other settings.


### PR DESCRIPTION
A discussed in #17 , this ensures that lux returns a float, even for `0`. Also updates doc string to explain potential for getting a `None` when computing lux is not possible.